### PR TITLE
Silence warning in "lint" CI job by specifying react version in eslintrc

### DIFF
--- a/mobile-app/.eslintrc
+++ b/mobile-app/.eslintrc
@@ -35,6 +35,9 @@
       "node": {
         "extensions": [".ts", ".tsx"]
       }
+    },
+    "react": {
+      "version": "detect"
     }
   }
 }


### PR DESCRIPTION
Each time the "lint" CI job ran, `eslint` spat out this warning:
<img width="945" alt="Screen Shot 2020-09-02 at 9 17 45 PM" src="https://user-images.githubusercontent.com/31291920/92060505-f1a5b180-ed61-11ea-911f-928c7ae5379e.png">

This PR proposes to correct this warning by specifying a React version in our `.eslintrc`

