### PR TITLE
Add first draft of Card component

### DIFF
--- a/mobile-app/src/components/Card.tsx
+++ b/mobile-app/src/components/Card.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {
+  Dimensions,
+  ImageBackground,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+// Styles
+
+const activeOpacity = 0.8;
+const borderRadius = 18;
+const deviceScreenWidth = Math.round(Dimensions.get('window').width);
+const cardWidth = Math.round(0.86 * deviceScreenWidth);
+const cardHeight = Math.round(0.82 * cardWidth);
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+  },
+  col: {
+    flexDirection: 'column',
+  },
+  card: {
+    width: cardWidth,
+    height: cardHeight,
+    marginBottom: 24,
+
+    shadowColor: 'black',
+    shadowOpacity: 0.35,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 8,
+  },
+  bgImg: {
+    width: '100%',
+    height: '100%',
+  },
+  labels: {
+    justifyContent: 'space-between',
+    marginTop: 'auto',
+    paddingTop: 12,
+    paddingBottom: 18,
+    paddingLeft: 18,
+    paddingRight: 18,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    borderBottomLeftRadius: borderRadius,
+    borderBottomRightRadius: borderRadius,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: 'white',
+  },
+  subtitle: {
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    color: '#aeaeb2',
+  },
+});
+
+// Component
+
+interface Props {
+  artwork: {
+    title: string;
+    artist: string;
+    imageURLs: string[];
+  };
+}
+
+const Card: React.FC<Props> = (props: Props) => (
+  <TouchableOpacity style={styles.card} activeOpacity={activeOpacity}>
+    <ImageBackground
+      source={{ uri: props.artwork.imageURLs[0] }}
+      style={styles.bgImg}
+      imageStyle={{ borderRadius }}>
+      <View style={[styles.labels, styles.row]}>
+        <View style={styles.col}>
+          <Text style={styles.title}>{props.artwork.title}</Text>
+          <Text style={styles.subtitle}>{props.artwork.artist}</Text>
+        </View>
+      </View>
+    </ImageBackground>
+  </TouchableOpacity>
+);
+
+export default Card;


### PR DESCRIPTION
Closes #7 

This PR introduces a first draft of the reusable `Card` component which will appear on the mobile application's landing screen. As of now, it looks like this on an iOS device:
<img width="246" alt="Screen Shot 2020-09-02 at 11 37 22 PM" src="https://user-images.githubusercontent.com/31291920/92068671-882f9e00-ed75-11ea-80b0-bc78145d9d14.png">

This component isn't displayed on the mobile app anywhere yet; this PR only has to do with the `Card.tsx` file.

The component is currently designed to receive data to display through props, but this may change. Lmk what y'alls thoughts are on this approach. Those props look like:

- An `artwork` object
    - The artwork's title
    - The artwork's artist name
    - A list of image URLs of the artwork
        - In the final version of the app, I envision that these URLs will point to publicly-viewable images in an S3 bucket (or somewhere in the cloud)