### PR TITLE
Expand ScrollView width to fill the device's screen

### DIFF
--- a/mobile-app/src/screens/ArtworkScreen.tsx
+++ b/mobile-app/src/screens/ArtworkScreen.tsx
@@ -1,46 +1,60 @@
 import React from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import { Title } from '../components/Title';
-import { Card, artwork} from '../components/Card';
-import { Spacer } from '../components/Spacer';
+import { Card, artwork } from '../components/Card';
 import { SearchBar } from '../components/SearchBar';
 import { ScrollView } from 'react-native-gesture-handler';
-
-
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
     paddingTop: 45,
     paddingBottom: Dimensions.get('window').height * 0.09,
   },
   gallery: {
-    // marginTop: 18,
-    marginBottom: 12,
-    marginHorizontal : 20,
-    paddingBottom: 0,
-  }
+    alignItems: 'center',
+    paddingBottom: 72,
+  },
 });
 
-const imageURLList: string[] = ["https://cdn.pixabay.com/photo/2017/08/30/12/45/girl-2696947_960_720.jpg"]
-const testArtwork : artwork = {title: "Test", artist: "Artist", imageURLs:imageURLList}
+const imageURLList: string[] = [
+  'https://cdn.pixabay.com/photo/2017/08/30/12/45/girl-2696947_960_720.jpg',
+];
+const testArtwork: artwork = {
+  title: 'Test',
+  artist: 'Artist',
+  imageURLs: imageURLList,
+};
 
-const imageURLList2: string[] = ["https://get.pxhere.com/photo/modern-art-art-graphic-design-child-art-watercolor-paint-painting-visual-arts-illustration-Colorfulness-graphics-paint-acrylic-paint-drawing-artwork-1568485.jpg"]
-const testArtwork2 : artwork = {title: "Test2", artist: "Artist2", imageURLs:imageURLList2}
+const imageURLList2: string[] = [
+  'https://get.pxhere.com/photo/modern-art-art-graphic-design-child-art-watercolor-paint-painting-visual-arts-illustration-Colorfulness-graphics-paint-acrylic-paint-drawing-artwork-1568485.jpg',
+];
+const testArtwork2: artwork = {
+  title: 'Test2',
+  artist: 'Artist2',
+  imageURLs: imageURLList2,
+};
 
-const imageURLList3: string[] = ["https://i1.pickpik.com/photos/561/876/856/various-art-brush-paint-preview.jpg"]
-const testArtwork3 : artwork = {title: "Test3", artist: "Artist3", imageURLs:imageURLList3}
+const imageURLList3: string[] = [
+  'https://i1.pickpik.com/photos/561/876/856/various-art-brush-paint-preview.jpg',
+];
+const testArtwork3: artwork = {
+  title: 'Test3',
+  artist: 'Artist3',
+  imageURLs: imageURLList3,
+};
 
 const ArtworkScreen: React.FC = () => (
   <View style={styles.container}>
     <Title text="Artwork Screen" />
-    <SearchBar text = "Search"/>
-    <ScrollView style={styles.gallery} showsVerticalScrollIndicator={false}>
-      <Card artwork = {testArtwork}></Card>
-      <Card artwork = {testArtwork2}></Card>
-      <Card artwork = {testArtwork3}></Card>
-      <Spacer text = ""></Spacer>
+    <SearchBar text="Search" />
+    <ScrollView
+      contentContainerStyle={styles.gallery}
+      showsVerticalScrollIndicator={false}>
+      <Card artwork={testArtwork}></Card>
+      <Card artwork={testArtwork2}></Card>
+      <Card artwork={testArtwork3}></Card>
+      {/* <Spacer text=""></Spacer> */}
     </ScrollView>
     {/* <Text>Artwork Cards will ultimately be displayed here!</Text> */}
   </View>

--- a/mobile-app/src/screens/ArtworkScreen.tsx
+++ b/mobile-app/src/screens/ArtworkScreen.tsx
@@ -54,9 +54,7 @@ const ArtworkScreen: React.FC = () => (
       <Card artwork={testArtwork}></Card>
       <Card artwork={testArtwork2}></Card>
       <Card artwork={testArtwork3}></Card>
-      {/* <Spacer text=""></Spacer> */}
     </ScrollView>
-    {/* <Text>Artwork Cards will ultimately be displayed here!</Text> */}
   </View>
 );
 


### PR DESCRIPTION
Widen the width of the `ScrollView` component on the artwork screen. This lets each `Card` component float in the center while still having enough room to let their drop shadows poke through on the sides.

Notice how the drop shadow is cut off on the left and right sides.

**Before**:
![IMG_A60B23A46C46-1](https://user-images.githubusercontent.com/31291920/94374311-5d690900-00d9-11eb-970a-ca5b5843d84f.jpeg)

**After**:
![IMG_BE100DD8C4DE-1](https://user-images.githubusercontent.com/31291920/94374327-7a9dd780-00d9-11eb-892f-7ca2b6059191.jpeg)