### PR TITLE
Tweak GitHub Actions to build and lint mobile-app project

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -1,14 +1,14 @@
-name: Lint
+name: Build & Lint
 
-on: 
+on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
 
 jobs:
-  run-linters:
-    name: Run linters
+  build-and-run-linter:
+    name: Build & run linter
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +25,10 @@ jobs:
         working-directory: ./mobile-app
         run: npm install
 
-      - name: Run linters
+      - name: Build proj
         working-directory: ./mobile-app
-        run: npx eslint . --ext .ts,.tsx --quiet
+        run: npm run build
+
+      - name: Run linter
+        working-directory: ./mobile-app
+        run: npm run lint

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -5,7 +5,9 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "eject": "expo eject"
+    "eject": "expo eject",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts,.tsx --quiet"
   },
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.10",


### PR DESCRIPTION
In the past, the team has run into trouble accepting PRs that failed to build. Depending on how simple the proposed changes are, none of the reviewers pull down the branch locally & try to compile the new work; they just take a look at the changes on GitHub's web interface.

This PR proposes to change our main GitHub Actions workflow which runs on each new PR against `master` so that it compiles all `.ts` and `.tsx` files in the `mobile-app/` project.