### PR TITLE
Bring in redux and wire back-end data to front-end

### DIFF
--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -13,6 +13,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/native": "^5.7.3",
     "@react-navigation/stack": "^5.9.0",
+    "@types/react-redux": "^7.1.9",
     "expo": "^38.0.10",
     "expo-status-bar": "^1.0.2",
     "react": "~16.11.0",
@@ -20,7 +21,10 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-screens": "~2.9.0",
-    "react-native-web": "~0.11.7"
+    "react-native-web": "~0.11.7",
+    "react-redux": "^7.2.1",
+    "redux": "^4.0.5",
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/mobile-app/src/App.tsx
+++ b/mobile-app/src/App.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { StatusBar } from 'react-native';
 import AppNavigator from './navigation/AppNavigator';
 import MediaPlayer from './components/MediaPlayer';
+import { configureStore } from './store';
+import { Provider } from 'react-redux';
 
 // A BIT OF HARDCODING TESTING HERE TOO......
 
+const store = configureStore();
+
 const App: React.FC = () => (
-  <>
+  <Provider store={store}>
     <StatusBar barStyle="dark-content" />
     <AppNavigator />
-    <MediaPlayer mediaTitle="Song Title"/>
-  </>
+    <MediaPlayer mediaTitle="Song Title" />
+  </Provider>
 );
 
 export default App;

--- a/mobile-app/src/App.tsx
+++ b/mobile-app/src/App.tsx
@@ -5,8 +5,6 @@ import MediaPlayer from './components/MediaPlayer';
 import { configureStore } from './store';
 import { Provider } from 'react-redux';
 
-// A BIT OF HARDCODING TESTING HERE TOO......
-
 const store = configureStore();
 
 const App: React.FC = () => (

--- a/mobile-app/src/components/Card.tsx
+++ b/mobile-app/src/components/Card.tsx
@@ -8,7 +8,7 @@ import {
   View,
 } from 'react-native';
 
-import {Tag} from './Tag'
+import { Tag } from './Tag';
 
 // Styles
 
@@ -18,9 +18,12 @@ const deviceScreenWidth = Math.round(Dimensions.get('window').width);
 const cardWidth = Math.round(0.86 * deviceScreenWidth);
 const cardHeight = Math.round(0.71 * cardWidth);
 
-
 //Generic art tags to use until we start pulling in database information
-const tagGeneric = [["Art", '#34c759'], ["Aart", '#5ac8fa'], ["Aaart", '#ff3b30']]
+const tagGeneric = [
+  ['Art', '#34c759'],
+  ['Aart', '#5ac8fa'],
+  ['Aaart', '#ff3b30'],
+];
 
 const styles = StyleSheet.create({
   row: {
@@ -66,45 +69,34 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     color: '#aeaeb2',
   },
-  taglist: {
-    
-  }
+  taglist: {},
 });
 
 // Component
 
 interface Props {
-  artwork: {
-    title: string;
-    artist: string;
-    imageURLs: string[];
-  };
-  tagdata: string[][];
-}
-
-export interface artwork {
   title: string;
   artist: string;
-  imageURLs: string[];
+  backgroundImg: string;
+  tagdata: string[][];
 }
 
 export const Card: React.FC<Props> = (props: Props) => (
   <TouchableOpacity style={styles.card} activeOpacity={activeOpacity}>
     <ImageBackground
-      source={{ uri: props.artwork.imageURLs[0] }}
+      source={{ uri: props.backgroundImg }}
       style={styles.bgImg}
       imageStyle={{ borderRadius }}>
       <View style={[styles.labels, styles.row]}>
         <View style={styles.col}>
-          <Text style={styles.title}>{props.artwork.title}</Text>
-          <Text style={styles.subtitle}>{props.artwork.artist}</Text>
+          <Text style={styles.title}>{props.title}</Text>
+          <Text style={styles.subtitle}>{props.artist}</Text>
         </View>
-        <Tag data={props.tagdata}/>
+        <Tag data={props.tagdata} />
       </View>
-    
+
       {/* <View style={[styles.labels, styles.row]}> */}
       {/* </View> */}
-      
     </ImageBackground>
   </TouchableOpacity>
 );

--- a/mobile-app/src/components/Card.tsx
+++ b/mobile-app/src/components/Card.tsx
@@ -18,13 +18,6 @@ const deviceScreenWidth = Math.round(Dimensions.get('window').width);
 const cardWidth = Math.round(0.86 * deviceScreenWidth);
 const cardHeight = Math.round(0.71 * cardWidth);
 
-//Generic art tags to use until we start pulling in database information
-const tagGeneric = [
-  ['Art', '#34c759'],
-  ['Aart', '#5ac8fa'],
-  ['Aaart', '#ff3b30'],
-];
-
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
@@ -94,9 +87,6 @@ export const Card: React.FC<Props> = (props: Props) => (
         </View>
         <Tag data={props.tagdata} />
       </View>
-
-      {/* <View style={[styles.labels, styles.row]}> */}
-      {/* </View> */}
     </ImageBackground>
   </TouchableOpacity>
 );

--- a/mobile-app/src/screens/ArtworkScreen.tsx
+++ b/mobile-app/src/screens/ArtworkScreen.tsx
@@ -69,9 +69,16 @@ const ArtworkScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
         )}
         {!props.isLoadingArtwork &&
           !props.didErrorOccurLoadingArtwork &&
-          props.artworkList.map((item, key) => {
-            // return <Card key={key} artwork={item} tagdata={jsonData[0].tags} />;
-            return <Text key={key}>{item.title}</Text>;
+          props.artworkList.map((artwork, key) => {
+            return (
+              <Card
+                key={key}
+                title={artwork.title}
+                artist={artwork.artist}
+                backgroundImg={artwork.imageURLs[0]}
+                tagdata={jsonData[0].tags}
+              />
+            );
           })}
       </ScrollView>
     </View>

--- a/mobile-app/src/screens/ArtworkScreen.tsx
+++ b/mobile-app/src/screens/ArtworkScreen.tsx
@@ -1,15 +1,28 @@
-import React from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
-import { Title } from '../components/Title';
-import { Card, artwork } from '../components/Card';
-import { SearchBar } from '../components/SearchBar';
-import { ScrollView } from 'react-native-gesture-handler';
+import React, { useEffect } from 'react';
 import jsonData from '../../assets/artwork_format.json';
+import { Artwork } from '../store/artwork/types';
+import { Card, artwork } from '../components/Card';
+import { RootState } from '../store';
+import { ScrollView } from 'react-native-gesture-handler';
+import { SearchBar } from '../components/SearchBar';
+import { Title } from '../components/Title';
+import { View, StyleSheet, Text, Dimensions } from 'react-native';
+import { connect, ConnectedProps } from 'react-redux';
+import { fetchAllArtworkFromCloud } from '../store/artwork/actions';
 
 // import * as jsonData from '.../assets/artwork_format.json'
 
+// Change the host that we hit to make API calls depending on if we're running in dev or prod.
+let host: string;
+// This env var will exist on an expo react native app, so it's safe to suppress this warning.
+// eslint-disable-next-line no-undef
+if (__DEV__) {
+  host = 'http://10.0.0.3:6969';
+} else {
+  host = 'public-address-for-some-remote-box';
+}
 
-
+// Styles.
 
 const styles = StyleSheet.create({
   container: {
@@ -23,28 +36,46 @@ const styles = StyleSheet.create({
   },
 });
 
+// Redux goodness.
 
-const ArtworkScreen: React.FC = () => {
+const mapState = (state: RootState) => ({
+  artworkList: state.artwork.list,
+  isLoadingArtwork: state.artwork.isLoading,
+  didErrorOccurLoadingArtwork: state.artwork.isError,
+});
+const mapDispatch = {
+  fetchAllArtworkFromCloud: () => fetchAllArtworkFromCloud(host),
+};
+const connector = connect(mapState, mapDispatch);
+type PropsFromRedux = ConnectedProps<typeof connector>;
 
+// Component.
+
+const ArtworkScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
   // const artworkData : string = JSON.parse(jsonData);
 
-  const cards = jsonData.map((item, key)=>{
-    const testArtwork : artwork = {title: item.title, artist: item.artist, imageURLs: item.imageURLs};
-    return (
-      <Card key = {key} artwork = {testArtwork} tagdata = { item.tags }></Card>
-  );
-  });
+  useEffect(() => props.fetchAllArtworkFromCloud(), []);
 
   return (
-  <View style={styles.container}>
-    <Title text="Artwork Screen" />
-    <SearchBar text = "Search"/>
-    <ScrollView contentContainerStyle={styles.gallery} showsVerticalScrollIndicator={false}>
-      { cards }
-
-    </ScrollView>
-  </View>
-  )
+    <View style={styles.container}>
+      <Title text="Artwork Screen" />
+      <SearchBar text="Search" />
+      <ScrollView
+        contentContainerStyle={styles.gallery}
+        showsVerticalScrollIndicator={false}>
+        {props.isLoadingArtwork && <Text>Loading...</Text>}
+        {props.didErrorOccurLoadingArtwork && (
+          <Text>Something went wrong fetching artwork from the cloud.</Text>
+        )}
+        {!props.isLoadingArtwork &&
+          !props.didErrorOccurLoadingArtwork &&
+          props.artworkList.map((item, key) => {
+            // return <Card key={key} artwork={item} tagdata={jsonData[0].tags} />;
+            return <Text key={key}>{item.title}</Text>;
+          })}
+      </ScrollView>
+    </View>
+  );
 };
 
-export default ArtworkScreen;
+export default connector(ArtworkScreen);

--- a/mobile-app/src/screens/ArtworkScreen.tsx
+++ b/mobile-app/src/screens/ArtworkScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import jsonData from '../../assets/artwork_format.json';
-import { Artwork } from '../store/artwork/types';
-import { Card, artwork } from '../components/Card';
+import { Card } from '../components/Card';
 import { RootState } from '../store';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SearchBar } from '../components/SearchBar';
@@ -9,8 +8,6 @@ import { Title } from '../components/Title';
 import { View, StyleSheet, Text, Dimensions } from 'react-native';
 import { connect, ConnectedProps } from 'react-redux';
 import { fetchAllArtworkFromCloud } from '../store/artwork/actions';
-
-// import * as jsonData from '.../assets/artwork_format.json'
 
 // Change the host that we hit to make API calls depending on if we're running in dev or prod.
 let host: string;
@@ -52,8 +49,9 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 // Component.
 
 const ArtworkScreen: React.FC<PropsFromRedux> = (props: PropsFromRedux) => {
-  // const artworkData : string = JSON.parse(jsonData);
-
+  // When the app first launches, reach out to the network to fetch all of the
+  // content this app will need to display, and throw it in the redux global
+  // store.
   useEffect(() => props.fetchAllArtworkFromCloud(), []);
 
   return (

--- a/mobile-app/src/store/artwork/actions.ts
+++ b/mobile-app/src/store/artwork/actions.ts
@@ -1,0 +1,47 @@
+import { AppThunk } from '..';
+import { Dispatch } from 'redux';
+import {
+  Artwork,
+  ArtworkActionTypes,
+  SET_LOADING_ERROR,
+  FETCH_ALL_ARTWORK_FROM_CLOUD,
+} from './types';
+
+// Action creator for the SET_LOADING_ERROR action type.
+export function setLoadingError(to: boolean): ArtworkActionTypes {
+  return {
+    type: SET_LOADING_ERROR,
+    payload: to,
+  };
+}
+
+// Action creator used by the fetchAllArtworkFromCloud() func.
+function addAllArtworkFromCloud(artwork: Artwork[]): ArtworkActionTypes {
+  return {
+    type: FETCH_ALL_ARTWORK_FROM_CLOUD,
+    payload: artwork,
+  };
+}
+
+// Thunk which makes an HTTP API call, then calls an action creator and dispatches that action
+// depending on the response from that API call.
+export function fetchAllArtworkFromCloud(host: string): AppThunk {
+  return (dispatch: Dispatch<ArtworkActionTypes>): void => {
+    fetch(`${host}/bucketContents`)
+      .then((response) =>
+        response.json().then((json) => ({
+          status: response.status,
+          json,
+        })),
+      )
+      .then(({ status, json }) => {
+        // TODO: more explicit error handling of different status codes.
+        if (status >= 400) {
+          dispatch(setLoadingError(true));
+        } else {
+          dispatch(addAllArtworkFromCloud(json));
+        }
+      })
+      .catch((err) => console.error(err)); // TODO: better error handling.
+  };
+}

--- a/mobile-app/src/store/artwork/reducers.ts
+++ b/mobile-app/src/store/artwork/reducers.ts
@@ -1,0 +1,35 @@
+import {
+  ArtworkState,
+  ArtworkActionTypes,
+  FETCH_ALL_ARTWORK_FROM_CLOUD,
+  SET_LOADING_ERROR,
+} from './types';
+
+const initialState: ArtworkState = {
+  list: [],
+  isLoading: true,
+  isError: false,
+};
+
+export default function artworkReducer(
+  state = initialState,
+  action: ArtworkActionTypes,
+): ArtworkState {
+  switch (action.type) {
+    case FETCH_ALL_ARTWORK_FROM_CLOUD:
+      return {
+        ...state,
+        list: action.payload,
+        isLoading: false,
+        isError: false,
+      };
+    case SET_LOADING_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        isError: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/mobile-app/src/store/artwork/types.ts
+++ b/mobile-app/src/store/artwork/types.ts
@@ -1,0 +1,33 @@
+export interface Artwork {
+  title: string;
+  artist: string;
+  description: string;
+  tags: string[];
+  imageURLs: string[];
+  critiques: Critique[];
+}
+
+export interface Critique {
+  title: string;
+  critic: string;
+  transcript: string;
+  tags: string[];
+}
+
+export interface ArtworkState {
+  list: Artwork[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export const FETCH_ALL_ARTWORK_FROM_CLOUD = 'ADD_ALL_ARTWORK_FROM_CLOUD';
+export const SET_LOADING_ERROR = 'SET_LOADING_ERROR';
+interface AddAllArtworkAction {
+  type: typeof FETCH_ALL_ARTWORK_FROM_CLOUD;
+  payload: Artwork[];
+}
+interface SetErrorFromFetchAction {
+  type: typeof SET_LOADING_ERROR;
+  payload: boolean;
+}
+export type ArtworkActionTypes = AddAllArtworkAction | SetErrorFromFetchAction;

--- a/mobile-app/src/store/index.ts
+++ b/mobile-app/src/store/index.ts
@@ -1,0 +1,22 @@
+import thunk, { ThunkAction } from 'redux-thunk';
+import { combineReducers, createStore, applyMiddleware, Action } from 'redux';
+import artworkReducer from './artwork/reducers';
+
+const rootReducer = combineReducers({
+  artwork: artworkReducer,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+// Type for the return value of all action creators that return a function instead of a new state
+// object.
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>;
+
+export function configureStore() {
+  return createStore(rootReducer, applyMiddleware(thunk));
+}

--- a/mobile-app/yarn.lock
+++ b/mobile-app/yarn.lock
@@ -934,7 +934,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -1304,6 +1304,14 @@
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.36.tgz#17ce0a235e9ffbcdcdf5095646b374c2bf615a4c"
   integrity sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -1340,6 +1348,16 @@
   integrity sha512-7QfU8EzIYxYqeXpPf8QNv2xi8hrePlgTbRATRo+plRSdVfJu7N6sAXqrFxKJp6bGLvp82GV1gczl93gqiAfXPA==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.9":
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.9.tgz#280c13565c9f13ceb727ec21e767abe0e9b4aec3"
+  integrity sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react@*", "@types/react@~16.9.41":
   version "16.9.49"
@@ -3402,6 +3420,13 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
@@ -5061,7 +5086,7 @@ react-dom@~16.11.0:
     prop-types "^15.6.2"
     scheduler "^0.17.0"
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5151,6 +5176,17 @@ react-native-web@~0.11.7:
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
 
+react-redux@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.1.tgz#8dedf784901014db2feca1ab633864dee68ad985"
+  integrity sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
+
 react-refresh@^0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
@@ -5182,6 +5218,19 @@ readable-stream@^2.0.1, readable-stream@^2.2.2, readable-stream@~2.3.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0, redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -5834,6 +5883,11 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
Redux acts as a global state manager for our mobile app. This will make it much easier for us to manage state across component hierarchies, as well as better organize the data that our mobile app is mutating and displaying.

This PR proposes to bring in the relevant dependencies to facilitate a Redux global store, as well as load data about the content that the mobile app displays into that store. As a starter, it also refactors the `Card` component to pull data from this global store.