### PR TITLE
Add POST /replaceExistingFile endpoint

### DIFF
--- a/mobile-app/src/components/CritiqueComponent.tsx
+++ b/mobile-app/src/components/CritiqueComponent.tsx
@@ -21,7 +21,7 @@ import {
 async function playAudio(
   url: string,
   currentSound: Audio.Sound,
-  setCurrentSound: (Sound: Audio.Sound) => ArtworkActionTypes,
+  setCurrentSound: (sound: Audio.Sound) => ArtworkActionTypes,
 ) {
   try {
     currentSound.unloadAsync();
@@ -118,7 +118,7 @@ const CritiqueComponent: React.FC<Props & PropsFromRedux> = (
       props.setIsPaused(false);
       props.setCurrentCritique(props.critique);
       playAudio(
-        props.critique.AudioURL,
+        props.critique.audioURL,
         props.currentSound,
         props.setCurrentSound,
       );

--- a/mobile-app/src/store/artwork/reducers.ts
+++ b/mobile-app/src/store/artwork/reducers.ts
@@ -1,14 +1,14 @@
 import { Audio } from 'expo-av'
 import {
-  ArtworkState,
   ArtworkActionTypes,
+  ArtworkState,
   FETCH_ALL_ARTWORK_FROM_CLOUD,
-  SET_LOADING_ERROR,
-  SET_SEARCH_QUERY,
   SET_CURRENT_ARTWORK,
   SET_CURRENT_CRITIQUE,
-  SET_IS_PAUSED,
   SET_CURRENT_SOUND,
+  SET_IS_PAUSED,
+  SET_LOADING_ERROR,
+  SET_SEARCH_QUERY,
 } from './types';
 // import { Artwork, Critique } from './types'
 
@@ -30,7 +30,7 @@ const initialState: ArtworkState = {
     critic: "",
     transcript: "",
     tags: [[]],
-    AudioURL: "",
+    audioURL: "",
   },
   isPlaying: false,
   isPaused: true,
@@ -77,9 +77,9 @@ export default function artworkReducer(
         isPaused: action.payload,
       }
     case SET_CURRENT_SOUND:
-        return {
-          ...state,
-          currentSound: action.payload,
+      return {
+        ...state,
+        currentSound: action.payload,
       }
     default:
       return state;

--- a/mobile-app/src/store/artwork/types.ts
+++ b/mobile-app/src/store/artwork/types.ts
@@ -14,7 +14,7 @@ export interface Critique {
   critic: string;
   transcript: string;
   tags: string[][];
-  AudioURL: string;
+  audioURL: string;
 }
 
 export interface ArtworkState {

--- a/server/bucket.go
+++ b/server/bucket.go
@@ -92,7 +92,7 @@ type CritiqueInfo struct {
 	Critic     string     `json:"critic"`
 	Transcript string     `json:"transcript"`
 	Tags       [][]string `json:"tags"`
-	AudioURL   string     `json:"audioURL`
+	AudioURL   string     `json:"audioURL"`
 }
 
 // FetchAllArtwork fetches information for all of the artwork in the S3 bucket.

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -27,6 +28,7 @@ func (s *Server) Start() {
 	// Register routes with their respective handler funcs.
 	http.HandleFunc("/hello", s.helloHandler)
 	http.HandleFunc("/bucketContents", s.bucketContentsHandler)
+	http.HandleFunc("/replaceExistingFile", s.replaceExistingFileHandler)
 
 	// Stand up the server.
 	log.Printf("Listening on port %d....", s.port)
@@ -49,6 +51,51 @@ func (s *Server) bucketContentsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	constructAndSendResponse(w, contents)
+}
+
+// ReplaceExistingJSONFileRequestBody represents the structure of the request body for a hit to the
+// POST /replaceExistingFile endpoint.
+type ReplaceExistingJSONFileRequestBody struct {
+	ObjectPath string      `json:"objectPath"`
+	Content    interface{} `json:"content"`
+}
+
+func (s *Server) replaceExistingFileHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "This endpoint only supports POST requests", http.StatusBadRequest)
+		return
+	}
+
+	// Extract request body into rb (request body) struct.
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	var rb ReplaceExistingJSONFileRequestBody
+	err := decoder.Decode(&rb)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if rb.ObjectPath == "" {
+		http.Error(w, "objectPath field must be present in request body", http.StatusBadRequest)
+		return
+	}
+	if rb.Content == nil {
+		http.Error(w, "content field must be present in request body", http.StatusBadRequest)
+		return
+	}
+
+	// Turn payload into a "file" (slice of bytes).
+	file, err := json.MarshalIndent(rb.Content, "", " ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Send that file off to the S3 bucket.
+	ioutil.WriteFile("testing.json", file, 0644) // TODO: TEMPORARY!
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // constructAndSendResponse adds important, common headers to endpoint responses, and marshals the

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -60,6 +59,7 @@ type ReplaceExistingJSONFileRequestBody struct {
 	Content    interface{} `json:"content"`
 }
 
+// replaceExistingFileHandler handles POST requests on the "/replaceExistingFile" route.
 func (s *Server) replaceExistingFileHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(w, "This endpoint only supports POST requests", http.StatusBadRequest)
@@ -93,7 +93,11 @@ func (s *Server) replaceExistingFileHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Send that file off to the S3 bucket.
-	ioutil.WriteFile("testing.json", file, 0644) // TODO: TEMPORARY!
+	err = s.bucket.ReplaceExistingJSONFile(rb.ObjectPath, file)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
Proposing a new `POST /replaceExistingFile` endpoint which will overwrite the contents of a file in our S3 bucket specified by its absolute path in that bucket. The plan is for our content management system to hit this when a user edits metadata about an artwork, and the corresponding `.json` file needs to reflect those changes.

This new endpoint's request body has the following structure:

```javascript
{
  "objectPath": string,
  "content": Object
}
```

**Example**: say a content management system user updates the Weeping Woman artwork title. The request body of that API call could look like:

```javascript
{
  "objectPath": "weeping-woman/weeping-woman.json",
  "content": {
    "title": "Weeping Woman Two",
    "artist": "da Vinci",
    "description": "Lorem ipsum dolor sit amet.",
    "tags": [
      ["Vintage", "#34c759"],
      ["Emotional", "#ff3b30"]
    ]
  }
}
```

Notice that the `"content"` field contains the new contents of the entire file. As a team, we decided that completely overwriting existing `.json` files in S3 would be easier than trying to implement granular field changes. The content management system front-end shouldn't have a problem constructing a JSON blob for an entire file's contents like this when it hits this new endpoint.