### PR TITLE
Add DELETE /bucket/:objectPath endpoint

### DIFF
--- a/server/api/bucket.go
+++ b/server/api/bucket.go
@@ -87,7 +87,7 @@ func (h *BucketHandler) deleteObjectHandler(w http.ResponseWriter, r *http.Reque
 	//
 	// TODO: validate URI structure. We aren't checking that the provided object path in the URI is
 	// present, much less valid.
-	objectPath := strings.TrimPrefix(r.URL.Path, resourcePrefix)
+	objectPath := strings.TrimPrefix(r.URL.Path+"/", resourcePrefix)
 
 	err := h.bucket.DeleteFile(objectPath)
 	if err != nil {

--- a/server/bucket/bucket.go
+++ b/server/bucket/bucket.go
@@ -325,12 +325,26 @@ func (b *Bucket) ReplaceExistingJSONFile(objectPath string, file []byte) error {
 
 // DeleteFile deletes the file at the provided object path in the S3 bucket.
 func (b *Bucket) DeleteFile(objectPath string) error {
-	_, err := b.svc.DeleteObject(&s3.DeleteObjectInput{
+	// List all objects whose absolute paths have the prefix: objectPath. If we're deleting one
+	// file, then this should only return one object path; if we're deleting a directory, then this
+	// should list all objects in that directory.
+	objects, err := b.svc.ListObjectsV2(&s3.ListObjectsV2Input{
 		Bucket: aws.String(b.name),
-		Key:    aws.String(objectPath),
+		Prefix: aws.String(objectPath),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to delete %s from bucket: %v", objectPath, err)
+		return fmt.Errorf("failed to list %s in bucket: %v", objectPath, err)
+	}
+
+	// Remove each object that we found.
+	for _, object := range objects.Contents {
+		_, err := b.svc.DeleteObject(&s3.DeleteObjectInput{
+			Bucket: aws.String(b.name),
+			Key:    object.Key,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete %s from bucket: %v", objectPath, err)
+		}
 	}
 
 	return nil

--- a/server/bucket/bucket.go
+++ b/server/bucket/bucket.go
@@ -322,3 +322,16 @@ func (b *Bucket) ReplaceExistingJSONFile(objectPath string, file []byte) error {
 
 	return nil
 }
+
+// DeleteFile deletes the file at the provided object path in the S3 bucket.
+func (b *Bucket) DeleteFile(objectPath string) error {
+	_, err := b.svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(b.name),
+		Key:    aws.String(objectPath),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete %s from bucket: %v", objectPath, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR proposes to introduce a new `DELETE /bucket/:objectPath` endpoint that can be used to delete individual files or entire directories in S3.