### PR TITLE
Add POST /bucket/:objectPath endpoint for file uploads

### DIFF
--- a/server/api/bucket.go
+++ b/server/api/bucket.go
@@ -42,7 +42,13 @@ func (h *BucketHandler) getContentsHandler(w http.ResponseWriter, r *http.Reques
 func (h *BucketHandler) objectSubResourceHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
-		h.postNewObjectHandler(w, r)
+		switch r.Header.Get("Content-Type") {
+		case "application/json":
+			h.postNewJSONObjectHandler(w, r)
+		default:
+			http.Error(w, "This POST endpoint expects the Content-Type header to either be "+
+				"application/json or multipart/form-data", http.StatusBadRequest)
+		}
 	case http.MethodDelete:
 		h.deleteObjectHandler(w, r)
 	default:
@@ -50,8 +56,9 @@ func (h *BucketHandler) objectSubResourceHandler(w http.ResponseWriter, r *http.
 	}
 }
 
-// postNewObjectHandler handles POST requests on the "/bucket/:objectPath" route.
-func (h *BucketHandler) postNewObjectHandler(w http.ResponseWriter, r *http.Request) {
+// postNewJSONObjectHandler handles POST requests on the "/bucket/:objectPath" route that have the
+// Content-Type=application/json header set.
+func (h *BucketHandler) postNewJSONObjectHandler(w http.ResponseWriter, r *http.Request) {
 	// Turn payload into a "file" (slice of bytes).
 	var requestBody interface{}
 	err := json.NewDecoder(r.Body).Decode(&requestBody)

--- a/server/api/bucket.go
+++ b/server/api/bucket.go
@@ -86,7 +86,7 @@ func (h *BucketHandler) postNewJSONObjectHandler(w http.ResponseWriter, r *http.
 	objectPath := strings.TrimPrefix(r.URL.Path, resourcePrefix)
 
 	// Send that file off to the S3 bucket.
-	err = h.bucket.ReplaceExistingJSONFile(objectPath, file)
+	err = h.bucket.ReplaceExistingFile(objectPath, file)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -121,7 +121,7 @@ func (h *BucketHandler) postNewFileObjectHandler(w http.ResponseWriter, r *http.
 	objectPath := strings.TrimPrefix(r.URL.Path, resourcePrefix)
 
 	// Send that file off to the S3 bucket.
-	err = h.bucket.ReplaceExistingJSONFile(objectPath, buffer.Bytes())
+	err = h.bucket.ReplaceExistingFile(objectPath, buffer.Bytes())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/bucket/bucket.go
+++ b/server/bucket/bucket.go
@@ -308,9 +308,9 @@ func addImage(fileURL string, artworkList []*ArtworkInfo, curArtworkIndex int) {
 	artworkList[curArtworkIndex].ImageURLs = append(curArtworkImagesList, fileURL)
 }
 
-// ReplaceExistingJSONFile replaces the file at the provided object path in the S3 bucket with a new
+// ReplaceExistingFile replaces the file at the provided object path in the S3 bucket with a new
 // one.
-func (b *Bucket) ReplaceExistingJSONFile(objectPath string, file []byte) error {
+func (b *Bucket) ReplaceExistingFile(objectPath string, file []byte) error {
 	_, err := b.uploader.Upload(&s3manager.UploadInput{
 		Bucket: aws.String(b.name),
 		Key:    aws.String(objectPath),


### PR DESCRIPTION
This PR proposes to introduce a new `POST /bucket/:objectPath` endpoint which looks for the `Content-Type: multipart/form-data` header.

When we create a form on the CMP front-end which hits this endpoint, it'll be important to make sure the file upload element has the value: `"file"`.